### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity to the activities list, addressing the time-sensitive student request in Issue #6.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Includes description referencing the GitHub Certifications program for college applications
- Schedule: Mondays and Fridays, 3:30 PM - 4:30 PM
- Capacity: 25 participants
- Status: Open for registration

## Fixes
Closes #6

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change

Students can now register for the GitHub Skills activity announced by the principal.